### PR TITLE
Update rapidjson dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ find_file(RAPIDJSONTEST NAMES rapidjson rapidjson-1.1.0 PATHS ${CMAKE_CURRENT_SO
 if (NOT RAPIDJSONTEST)
     message("no rapidjson, download")
     set(RJ_TAR_FILE ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/v1.1.0.tar.gz)
-    file(DOWNLOAD https://github.com/miloyip/rapidjson/archive/v1.1.0.tar.gz ${RJ_TAR_FILE})
+    file(DOWNLOAD https://github.com/Tencent/rapidjson/archive/7c73dd7de7c4f14379b781418c6e947ad464c818.tar.gz ${RJ_TAR_FILE})
     execute_process(
         COMMAND ${CMAKE_COMMAND} -E tar xzf ${RJ_TAR_FILE}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty
@@ -44,7 +44,7 @@ if (NOT RAPIDJSONTEST)
     file(REMOVE ${RJ_TAR_FILE})
 endif(NOT RAPIDJSONTEST)
 
-find_file(RAPIDJSON NAMES rapidjson rapidjson-1.1.0 PATHS ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty CMAKE_FIND_ROOT_PATH_BOTH)
+find_file(RAPIDJSON NAMES rapidjson rapidjson-7c73dd7de7c4f14379b781418c6e947ad464c818 PATHS ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty CMAKE_FIND_ROOT_PATH_BOTH)
 
 add_library(rapidjson STATIC IMPORTED ${RAPIDJSON})
 


### PR DESCRIPTION
Updates rapidjson to use the latest commit instead of the 1.1.0 release, which fails to compile due to a faulty constructor (https://github.com/Tencent/rapidjson/issues/2277)